### PR TITLE
Fix the bug that causes memory allocation duplication, as it is preve…

### DIFF
--- a/launch/bfs/bfs.h
+++ b/launch/bfs/bfs.h
@@ -12,7 +12,7 @@
 #include "../../utils/split_huge_page.h"
 
 void init_kernel(int num_nodes, int start_seed, unsigned long *in_index, unsigned long *out_index, unsigned long **in_wl, unsigned long **out_wl, unsigned long **ret) {
-  *ret = (unsigned long *) malloc(sizeof(unsigned long) * num_nodes);
+  //*ret = (unsigned long *) malloc(sizeof(unsigned long) * num_nodes);
   *in_wl = (unsigned long *) malloc(sizeof(unsigned long) * num_nodes * 2);
   *out_wl = (unsigned long *) malloc(sizeof(unsigned long) * num_nodes * 2);
 

--- a/launch/pagerank/pr.h
+++ b/launch/pagerank/pr.h
@@ -15,7 +15,7 @@ float alpha = 0.85;
 float epsilon = 0.01;
 
 void init_kernel(unsigned long num_nodes, float **x, float **in_r, unsigned long *in_index, unsigned long *out_index, unsigned long **in_wl, unsigned long **out_wl, float **ret) {
-  *ret = (float *) malloc(sizeof(float) * num_nodes);
+  //*ret = (float *) malloc(sizeof(float) * num_nodes);
   *x = (float *) malloc(sizeof(float) * num_nodes);
   *in_r = (float *) malloc(sizeof(float) * num_nodes);
   *in_wl = (unsigned long *) malloc(sizeof(unsigned long) * num_nodes);

--- a/launch/sssp/sssp.h
+++ b/launch/sssp/sssp.h
@@ -12,7 +12,7 @@
 #include "../../utils/split_huge_page.h"
 
 void init_kernel(unsigned long num_nodes, int start_seed, unsigned long *in_index, unsigned long *out_index, unsigned long **in_wl, unsigned long **out_wl, unsigned long **ret) {
-  *ret = (unsigned long *) malloc(sizeof(unsigned long) * num_nodes);
+  //*ret = (unsigned long *) malloc(sizeof(unsigned long) * num_nodes);
   *in_wl = (unsigned long *) malloc(sizeof(unsigned long) * num_nodes * 5);
   *out_wl = (unsigned long *) malloc(sizeof(unsigned long) * num_nodes * 5);
 


### PR DESCRIPTION
…nting 'madvise' from working properly.

In "bfs/main.cpp", we allocate memory use code below:
```
void create_irreg_data(int run_kernel, unsigned long** ret) {
void *tmp = nullptr;
posix_memalign(&tmp, 1 << 21, num_nodes * sizeof(unsigned long));
*ret = static_cast<unsigned long>(tmp);
...
int err = madvise(*ret, num_nodes * sizeof(unsigned long), MADV_HUGEPAGE);
...
```
However, we then call a function named 'init_kernel()', which also allocates memory for the pointer '*ret' using
```
void init_kernel(int num_nodes, int start_seed, unsigned long *in_index, unsigned long *out_index, unsi
gned long **in_wl, unsigned long **out_wl, unsigned long **ret) {
*ret = (unsigned long *) malloc(sizeof(unsigned long) * num_nodes);
...
}
```
This means that the earlier allocation is redundant and renders 'madvise()' useless.

The issue is present in 'sssp.cpp' and 'pangrank.cpp' as well.